### PR TITLE
Improvements to the AclQueryAugmentor.

### DIFF
--- a/src/main/java/demo/AclQueryAugmentor.java
+++ b/src/main/java/demo/AclQueryAugmentor.java
@@ -1,5 +1,14 @@
 package demo;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
@@ -16,6 +25,7 @@ import org.springframework.data.repository.augment.QueryContext.QueryMode;
 import org.springframework.data.repository.augment.UpdateContext.UpdateMode;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
 
 public class AclQueryAugmentor<T> extends
 		AnnotationBasedQueryAugmentor<Acled, JpaCriteriaQueryContext<?, ?>, JpaQueryContext, JpaUpdateContext<T, ?>> {
@@ -33,9 +43,12 @@ public class AclQueryAugmentor<T> extends
 			return context;
 		}
 
-		return context.augment("Permission p",
-				String.format("{alias}.id = p.domainId and p.permission = '%s' and p.domainType = '%s' and p.username = '%s'",
-						getRequiredPermission(context.getMode()), MyDomain.class.getName(), authentication.getName()));
+		JpaEntityInformation<?, ?> entityInformation = context.getEntityInformation();
+
+		WhereClause clause = getIdGuard(entityInformation.getIdAttribute().getName())
+				.and(getPermissionGuard(getClass(), context.getMode(), authentication));
+
+		return context.augment("Permission p", clause.toString(), clause.getParameters());
 	}
 
 	/* 
@@ -53,6 +66,23 @@ public class AclQueryAugmentor<T> extends
 	 */
 	@Override
 	protected JpaUpdateContext<T, ?> prepareUpdate(JpaUpdateContext<T, ?> context, Acled annotation) {
+
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null) {
+			return context;
+		}
+
+		if (context.isNewEntity()) {
+
+			WhereClause whereClause = getPermissionGuard(context.getEntity().getClass(), QueryMode.FOR_UPDATE,
+					authentication);
+
+			boolean result = context.getQueryExecutor()
+					.execute("select count(p) > 0 from Permission p " + whereClause.toWhereString(), whereClause.getParameters());
+
+			return result ? context : null;
+		}
 
 		QueryMode mode = context.getMode().equals(UpdateMode.DELETE) ? QueryMode.FOR_DELETE : QueryMode.FOR_UPDATE;
 		QueryExecutor<T, ?> queryExecutor = context.getQueryExecutor();
@@ -96,6 +126,87 @@ public class AclQueryAugmentor<T> extends
 		criteriaQuery.where(restriction == null ? predicate : builder.and(restriction, predicate));
 
 		return context;
+	}
+
+	private WhereClause getIdGuard(String identifierProperty) {
+		return new WhereClause(String.format("{alias.%s = p.domainId", identifierProperty));
+	}
+
+	private WhereClause getPermissionGuard(Class<?> domainType, QueryMode mode, Authentication authentication) {
+
+		WhereClause where = new WhereClause("p.permission = :acl_permission", getRequiredPermission(mode));
+		where = where.and("p.domainType = :acl_domainType", domainType.getName());
+		return where.and("p.username = :acl_username", authentication.getName());
+	}
+
+	private static class WhereClause {
+
+		private static final Pattern PARAMETER = Pattern.compile(":(\\w+)");
+
+		private final List<String> clause;
+		private final Map<String, Object> parameters;
+
+		public WhereClause(String clause) {
+			this(clause, null);
+		}
+
+		public WhereClause(String clause, Object value) {
+
+			this.clause = Arrays.asList(clause);
+			this.parameters = value == null ? Collections.emptyMap()
+					: Collections.singletonMap(getParameterName(clause), value);
+		}
+
+		/**
+		 * @param clause
+		 * @param parameters
+		 */
+		private WhereClause(List<String> clause, Map<String, Object> parameters) {
+			this.clause = clause;
+			this.parameters = parameters;
+		}
+
+		public WhereClause and(WhereClause clause) {
+
+			List<String> clauses = new ArrayList<String>(this.clause);
+			clauses.addAll(clause.clause);
+
+			Map<String, Object> parameters = new HashMap<String, Object>(this.parameters);
+			parameters.putAll(clause.parameters);
+
+			return new WhereClause(clauses, parameters);
+		}
+
+		public WhereClause and(String clause) {
+			return and(clause, null);
+		}
+
+		public WhereClause and(String clause, Object parameter) {
+			return and(new WhereClause(clause, parameter));
+		}
+
+		public Map<String, Object> getParameters() {
+			return Collections.unmodifiableMap(parameters);
+		}
+
+		public String toWhereString() {
+			return "where ".concat(toString());
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see java.lang.Object#toString()
+		 */
+		@Override
+		public String toString() {
+			return StringUtils.collectionToDelimitedString(clause, " and ");
+		}
+
+		private static String getParameterName(String clause) {
+
+			Matcher matcher = PARAMETER.matcher(clause);
+			return matcher.find() ? matcher.group(1) : null;
+		}
 	}
 
 	private static String getRequiredPermission(QueryMode mode) {

--- a/src/test/java/demo/DemoApplicationTests.java
+++ b/src/test/java/demo/DemoApplicationTests.java
@@ -60,12 +60,17 @@ public class DemoApplicationTests {
 	@WithMockUser("luke")
 	@Test
 	public void saveCreateNoPermission() {
+
+		long before = unaugmentedRepository.count();
+
 		MyDomain toSave = new MyDomain();
 		toSave.setAttribute("saveCreateNoPermission");
 
 		// TODO not sure how this should fail saved == null || just null id || exception
-		MyDomain saved = repository.save(toSave);
-		assertThat(unaugmentedRepository.findOne(saved.getId())).isNotNull();
+		repository.save(toSave);
+
+		assertThat(unaugmentedRepository.count()).isEqualTo(before);
+		assertThat(toSave.getId()).isNull();
 	}
 
 	@WithMockUser("rob")


### PR DESCRIPTION
Introduced WhereClause value object to easily build where clauses and capture parameters. We now also guard the execution of an update for previously unsaved objects by checking whether we we find at least one for-update permission on the given domain type.

Improved test for rejected save on new object by checking the number of items in the store are the same before and after the attempt to save the object. Also checking that no identifier has been assigned to the instance.
